### PR TITLE
[network] 마이페이지 api 연결

### DIFF
--- a/Totori/Network/API/TotoriAPI.swift
+++ b/Totori/Network/API/TotoriAPI.swift
@@ -21,6 +21,9 @@ enum TotoriAPI {
     case generateBook(param: BookGenerateRequestDTO)
     case mainStatus
     case bookList(page: Int, size: Int)
+    
+    //member
+    case acorn
 }
 
 extension TotoriAPI: BaseTargetType {
@@ -43,6 +46,10 @@ extension TotoriAPI: BaseTargetType {
             return "/api/books/main-status"
         case .bookList:
             return "/api/books"
+            
+            //member
+        case .acorn:
+            return "/api/members/me/acorns"
         }
     }
     
@@ -50,7 +57,7 @@ extension TotoriAPI: BaseTargetType {
         switch self {
         case .login, .signUp, .generateBook, .reissue, .attendance:
             return .post
-        case .mainStatus, .bookList:
+        case .mainStatus, .bookList, .acorn:
             return .get
         }
     }
@@ -73,6 +80,8 @@ extension TotoriAPI: BaseTargetType {
                 encoding: URLEncoding.queryString
             )
         case .attendance:
+            return .requestPlain
+        case .acorn:
             return .requestPlain
         }
     }

--- a/Totori/Network/API/TotoriAPI.swift
+++ b/Totori/Network/API/TotoriAPI.swift
@@ -27,6 +27,7 @@ enum TotoriAPI {
     
     //badge
     case myRepresentativeBadge
+    case myAllBadges
 }
 
 extension TotoriAPI: BaseTargetType {
@@ -57,6 +58,8 @@ extension TotoriAPI: BaseTargetType {
             //badge
         case .myRepresentativeBadge:
             return "/api/badges/my/representative"
+        case .myAllBadges:
+            return "/api/badges/my"
         }
     }
     
@@ -64,7 +67,7 @@ extension TotoriAPI: BaseTargetType {
         switch self {
         case .login, .signUp, .generateBook, .reissue, .attendance:
             return .post
-        case .mainStatus, .bookList, .acorn, .myRepresentativeBadge:
+        case .mainStatus, .bookList, .acorn, .myRepresentativeBadge, .myAllBadges:
             return .get
         }
     }
@@ -91,6 +94,8 @@ extension TotoriAPI: BaseTargetType {
         case .acorn:
             return .requestPlain
         case .myRepresentativeBadge:
+            return .requestPlain
+        case .myAllBadges:
             return .requestPlain
         }
     }

--- a/Totori/Network/API/TotoriAPI.swift
+++ b/Totori/Network/API/TotoriAPI.swift
@@ -24,6 +24,9 @@ enum TotoriAPI {
     
     //member
     case acorn
+    
+    //badge
+    case myRepresentativeBadge
 }
 
 extension TotoriAPI: BaseTargetType {
@@ -50,6 +53,10 @@ extension TotoriAPI: BaseTargetType {
             //member
         case .acorn:
             return "/api/members/me/acorns"
+            
+            //badge
+        case .myRepresentativeBadge:
+            return "/api/badges/my/representative"
         }
     }
     
@@ -57,7 +64,7 @@ extension TotoriAPI: BaseTargetType {
         switch self {
         case .login, .signUp, .generateBook, .reissue, .attendance:
             return .post
-        case .mainStatus, .bookList, .acorn:
+        case .mainStatus, .bookList, .acorn, .myRepresentativeBadge:
             return .get
         }
     }
@@ -82,6 +89,8 @@ extension TotoriAPI: BaseTargetType {
         case .attendance:
             return .requestPlain
         case .acorn:
+            return .requestPlain
+        case .myRepresentativeBadge:
             return .requestPlain
         }
     }

--- a/Totori/Network/API/TotoriAPI.swift
+++ b/Totori/Network/API/TotoriAPI.swift
@@ -28,6 +28,7 @@ enum TotoriAPI {
     //badge
     case myRepresentativeBadge
     case myAllBadges
+    case categoryBadges(category: String)
 }
 
 extension TotoriAPI: BaseTargetType {
@@ -60,6 +61,8 @@ extension TotoriAPI: BaseTargetType {
             return "/api/badges/my/representative"
         case .myAllBadges:
             return "/api/badges/my"
+        case .categoryBadges(let category):
+            return "/api/badges/my/categories/\(category)"
         }
     }
     
@@ -67,7 +70,7 @@ extension TotoriAPI: BaseTargetType {
         switch self {
         case .login, .signUp, .generateBook, .reissue, .attendance:
             return .post
-        case .mainStatus, .bookList, .acorn, .myRepresentativeBadge, .myAllBadges:
+        case .mainStatus, .bookList, .acorn, .myRepresentativeBadge, .myAllBadges, .categoryBadges:
             return .get
         }
     }
@@ -96,6 +99,8 @@ extension TotoriAPI: BaseTargetType {
         case .myRepresentativeBadge:
             return .requestPlain
         case .myAllBadges:
+            return .requestPlain
+        case .categoryBadges(_):
             return .requestPlain
         }
     }

--- a/Totori/Network/Badge/BadgeService.swift
+++ b/Totori/Network/Badge/BadgeService.swift
@@ -17,4 +17,8 @@ class BadgeService {
     func getMyRepresentativeBadge() -> AnyPublisher<RepresentativeBadgeResponseDTO, NetworkError> {
         return networkService.request(.myRepresentativeBadge, responseType: RepresentativeBadgeResponseDTO.self)
     }
+    
+    func getMyAllBadges() -> AnyPublisher<AllBadgesResponseDTO, NetworkError> {
+        return networkService.request(.myAllBadges, responseType: AllBadgesResponseDTO.self)
+    }
 }

--- a/Totori/Network/Badge/BadgeService.swift
+++ b/Totori/Network/Badge/BadgeService.swift
@@ -21,4 +21,8 @@ class BadgeService {
     func getMyAllBadges() -> AnyPublisher<AllBadgesResponseDTO, NetworkError> {
         return networkService.request(.myAllBadges, responseType: AllBadgesResponseDTO.self)
     }
+    
+    func getCategoryBadges(category: String) -> AnyPublisher<CategoryBadgeResponseDTO, NetworkError> {
+        return networkService.request(.categoryBadges(category: category), responseType: CategoryBadgeResponseDTO.self)
+    }
 }

--- a/Totori/Network/Badge/BadgeService.swift
+++ b/Totori/Network/Badge/BadgeService.swift
@@ -1,0 +1,20 @@
+//
+//  BadgeService.swift
+//  Totori
+//
+//  Created by 복지희 on 5/4/26.
+//
+
+import Combine
+import Foundation
+
+import CombineMoya
+import Moya
+
+class BadgeService {
+    private let networkService = BaseService<TotoriAPI>()
+    
+    func getMyRepresentativeBadge() -> AnyPublisher<RepresentativeBadgeResponseDTO, NetworkError> {
+        return networkService.request(.myRepresentativeBadge, responseType: RepresentativeBadgeResponseDTO.self)
+    }
+}

--- a/Totori/Network/Badge/DTO/BadgeDTO.swift
+++ b/Totori/Network/Badge/DTO/BadgeDTO.swift
@@ -9,8 +9,8 @@ import Foundation
 
 struct BadgeInfoDTO: Decodable {
     let id: Int
-    let category: String?
-    let categoryName: String?
+    let category: String
+    let categoryName: String
     let name: String
     let level: Int
     let targetValue: Int

--- a/Totori/Network/Badge/DTO/BadgeDTO.swift
+++ b/Totori/Network/Badge/DTO/BadgeDTO.swift
@@ -1,0 +1,27 @@
+//
+//  BadgeDTO.swift
+//  Totori
+//
+//  Created by 복지희 on 5/4/26.
+//
+
+import Foundation
+
+struct BadgeInfoDTO: Decodable {
+    let id: Int
+    let category: String?
+    let categoryName: String?
+    let name: String
+    let level: Int
+    let targetValue: Int
+    let imageUrl: String
+}
+
+struct BadgeDetailDTO: Decodable {
+    let badgeId: Int
+    let name: String
+    let level: Int
+    let targetValue: Int
+    let imageUrl: String
+    let isAcquired: Bool
+}

--- a/Totori/Network/Badge/DTO/CategoryBadgeResponseDTO.swift
+++ b/Totori/Network/Badge/DTO/CategoryBadgeResponseDTO.swift
@@ -1,0 +1,15 @@
+//
+//  CategoryBadgeResponseDTO.swift
+//  Totori
+//
+//  Created by 복지희 on 5/4/26.
+//
+
+import Foundation
+
+struct CategoryBadgeResponseDTO: Decodable {
+    let category: String
+    let categoryName: String
+    let currentCount: Int
+    let badges: [BadgeDetailDTO]
+}

--- a/Totori/Network/Badge/DTO/MemberBadgeResponseDTO.swift
+++ b/Totori/Network/Badge/DTO/MemberBadgeResponseDTO.swift
@@ -1,0 +1,20 @@
+//
+//  MemberBadgeResponseDTO.swift
+//  Totori
+//
+//  Created by 복지희 on 5/4/26.
+//
+
+import Foundation
+
+struct MemberBadgeResponseDTO: Decodable {
+    let memberBadgeId: Int
+    let badgeResponseDto: BadgeInfoDTO
+    let acquiredAt: String
+}
+
+// 전체 획득 뱃지 리스트 응답
+typealias AllBadgesResponseDTO = [MemberBadgeResponseDTO]
+
+// 대표 뱃지 응답
+typealias RepresentativeBadgeResponseDTO = MemberBadgeResponseDTO

--- a/Totori/Network/Member/DTO/AcornResponseDTO.swift
+++ b/Totori/Network/Member/DTO/AcornResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  AcornResponseDTO.swift
+//  Totori
+//
+//  Created by 복지희 on 5/3/26.
+//
+
+import Foundation
+
+struct AcornResponseDTO: Decodable {
+    let name: String
+    let acorn: Int
+}

--- a/Totori/Network/Member/MemberService.swift
+++ b/Totori/Network/Member/MemberService.swift
@@ -1,0 +1,20 @@
+//
+//  MemberService.swift
+//  Totori
+//
+//  Created by 복지희 on 5/3/26.
+//
+
+import Combine
+import Foundation
+
+import CombineMoya
+import Moya
+
+class MemberService {
+    private let networkService = BaseService<TotoriAPI>()
+    
+    func getAcorn() -> AnyPublisher<AcornResponseDTO, NetworkError> {
+        return networkService.request(.acorn, responseType: AcornResponseDTO.self)
+    }
+}

--- a/Totori/Presentation/Common/Components/BadgeCard.swift
+++ b/Totori/Presentation/Common/Components/BadgeCard.swift
@@ -26,8 +26,10 @@ struct BadgeCard: View {
                                 .fill(Color.white)
                         }
                         .resizable()
-                        .scaledToFit()
-                        .frame(width: 66, height: 66)
+                        .scaledToFill()
+                        .frame(width: 60, height: 60)
+                        .clipped()
+                        .cornerRadius(16)
                 } else {
                     RoundedRectangle(cornerRadius: 16)
                         .fill(Color.white)

--- a/Totori/Presentation/Common/Models/BadgeCategory.swift
+++ b/Totori/Presentation/Common/Models/BadgeCategory.swift
@@ -1,0 +1,28 @@
+//
+//  BadgeCategory.swift
+//  Totori
+//
+//  Created by user on 5/7/26.
+//
+
+import Foundation
+
+enum BadgeCategory: String {
+    case bookCreated = "BOOK_CREATED"
+    case bookRead = "BOOK_READ"
+    case attendance = "ATTENDANCE"
+    case acorn = "ACORN"
+
+    func getSubtitle(current: Int, target: Int) -> String {
+        switch self {
+        case .bookCreated:
+            return "책 \(target)권 생성하기 (\(current)/\(target))"
+        case .bookRead:
+            return "동화 \(target)권 읽기 도전 중! (\(current)/\(target))"
+        case .attendance:
+            return "연속 출석 \(target)일 달성하기 (\(current)/\(target)일)"
+        case .acorn:
+            return "도토리 총 \(target)개 모으기 (\(current)/\(target))"
+        }
+    }
+}

--- a/Totori/Presentation/Main/MainView.swift
+++ b/Totori/Presentation/Main/MainView.swift
@@ -12,7 +12,7 @@ struct MainView: View {
     @StateObject private var attendance = AttendanceViewModel()
     
     @State private var navigateToMyPage: Bool = false
-    @State private var navigateToBadgeInfo: Bool = false
+    @State private var selectedCategory: BadgeCategory?
     @State private var navigateToSetting: Bool = false
     
     let columns = [
@@ -66,7 +66,7 @@ struct MainView: View {
                             progress: viewModel.goalProgress,
                             imageUrl: viewModel.goalImageURL,
                             onTap: {
-                                navigateToBadgeInfo = true
+                                selectedCategory = viewModel.representativeCategory
                             }
                         )
                         .padding(20)
@@ -123,8 +123,8 @@ struct MainView: View {
             MyPageMainView()
                 .navigationBarBackButtonHidden(true)
         }
-        .navigationDestination(isPresented: $navigateToBadgeInfo) {
-            MyPageBadgeView()
+        .navigationDestination(item: $selectedCategory) { category in
+            MyPageBadgeView(category: category)
                 .navigationBarBackButtonHidden(true)
         }
     }

--- a/Totori/Presentation/Main/MainView.swift
+++ b/Totori/Presentation/Main/MainView.swift
@@ -13,6 +13,7 @@ struct MainView: View {
     
     @State private var navigateToMyPage: Bool = false
     @State private var selectedCategory: BadgeCategory?
+    @State private var selectedBadgeId: Int = 0
     @State private var navigateToSetting: Bool = false
     
     let columns = [
@@ -66,7 +67,8 @@ struct MainView: View {
                             progress: viewModel.goalProgress,
                             imageUrl: viewModel.goalImageURL,
                             onTap: {
-                                selectedCategory = viewModel.representativeCategory
+                                selectedCategory = viewModel.goalCategory
+                                selectedBadgeId = viewModel.goalId
                             }
                         )
                         .padding(20)
@@ -124,7 +126,7 @@ struct MainView: View {
                 .navigationBarBackButtonHidden(true)
         }
         .navigationDestination(item: $selectedCategory) { category in
-            MyPageBadgeView(category: category)
+            MyPageBadgeView(category: category, initialBadgeId: selectedBadgeId)
                 .navigationBarBackButtonHidden(true)
         }
     }

--- a/Totori/Presentation/Main/MainViewModel.swift
+++ b/Totori/Presentation/Main/MainViewModel.swift
@@ -43,6 +43,7 @@ class MainViewModel: ObservableObject {
     @Published var goalProgress: Double = 0.4
     @Published var goalImageURL: String? = nil
     @Published var hasBadge: Bool = false
+    @Published var representativeCategory: BadgeCategory = .acorn
     
     // bookList
     @Published var bookItems: [BookList] = []
@@ -171,6 +172,8 @@ class MainViewModel: ObservableObject {
     }
     
     private func applyBadge(_ badge: BadgeDTO?) {
+        let category = BadgeCategory(rawValue: badge?.category ?? "") ?? .acorn
+        
         guard let badge = badge else {
             hasBadge = false
             goalTitle = "아직 획득한 뱃지가 없어요"
@@ -185,7 +188,11 @@ class MainViewModel: ObservableObject {
         let current = badge.targetValue
         let total = badge.targetValue
         
-        goalSubtitle = "\(badge.name) (\(current)/\(total))"
+        representativeCategory = category
+        goalSubtitle = category.getSubtitle(
+            current: badge.level,
+            target: badge.targetValue
+        )
         goalProgress = total > 0 ? Double(current) / Double(total) : 0.0
         goalImageURL = badge.imageUrl
     }

--- a/Totori/Presentation/Main/MainViewModel.swift
+++ b/Totori/Presentation/Main/MainViewModel.swift
@@ -43,7 +43,8 @@ class MainViewModel: ObservableObject {
     @Published var goalProgress: Double = 0.4
     @Published var goalImageURL: String? = nil
     @Published var hasBadge: Bool = false
-    @Published var representativeCategory: BadgeCategory = .acorn
+    @Published var goalCategory: BadgeCategory = .acorn
+    @Published var goalId: Int = 0
     
     // bookList
     @Published var bookItems: [BookList] = []
@@ -188,7 +189,8 @@ class MainViewModel: ObservableObject {
         let current = badge.targetValue
         let total = badge.targetValue
         
-        representativeCategory = category
+        goalCategory = category
+        goalId = badge.id
         goalSubtitle = category.getSubtitle(
             current: badge.level,
             target: badge.targetValue

--- a/Totori/Presentation/MyPage/BadgeGridCell.swift
+++ b/Totori/Presentation/MyPage/BadgeGridCell.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import Kingfisher
+
 struct BadgeGridCell: View {
     let badge: BadgeItem
     
@@ -38,17 +40,16 @@ struct BadgeGridCell: View {
                         .stroke(outerStroke, lineWidth: 4)
                 )
             
-            RoundedRectangle(cornerRadius: 16)
-                .fill(innerBackground)
+            KFImage(URL(string: badge.imageUrl))
+                .placeholder {
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(Color.white)
+                }
+                .resizable()
+                .grayscale(badge.isUnlocked ? 0 : 1)
+                .scaledToFit()
                 .frame(height: 89)
                 .padding(15)
-
-            Image(badge.isUnlocked ? .badgePurple : .badgeGray)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 66, height: 66)
-                .padding(.horizontal, 6)
-                .padding(.bottom, 6)
         }
         .shadow(color: Color.black.opacity(0.01), radius: 20, x: 0, y: 4)
     }

--- a/Totori/Presentation/MyPage/BadgeListCell.swift
+++ b/Totori/Presentation/MyPage/BadgeListCell.swift
@@ -8,6 +8,8 @@
 
 import SwiftUI
 
+import Kingfisher
+
 struct BadgeListCell: View {
     let badge: BadgeListItem
     
@@ -18,11 +20,17 @@ struct BadgeListCell: View {
     var body: some View {
         HStack(spacing: 10) {
             
-            // TODO: - 뱃지 이미지 url로 변경
-            Image(.badgePurple)
+            KFImage(URL(string: badge.imageUrl))
+                .placeholder {
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(Color.white)
+                        .frame(width: 60, height: 60)
+                }
                 .resizable()
-                .scaledToFit()
+                .scaledToFill()
                 .frame(width: 60, height: 60)
+                .clipped()
+                .cornerRadius(16)
             
             VStack(alignment: .leading, spacing: 0) {
                 Text(badge.title)

--- a/Totori/Presentation/MyPage/MyPageBadgeView.swift
+++ b/Totori/Presentation/MyPage/MyPageBadgeView.swift
@@ -7,9 +7,13 @@
 
 import SwiftUI
 
+import Kingfisher
+
 struct MyPageBadgeView: View {
 
     let category: BadgeCategory
+    let initialBadgeId: Int
+    
     @StateObject private var viewModel = MyPageBadgeViewModel()
 
     var body: some View {
@@ -44,7 +48,7 @@ struct MyPageBadgeView: View {
             }
         }
         .onAppear {
-            viewModel.fetchAll(category: category)
+            viewModel.fetchAll(category: category, initialBadgeId: initialBadgeId)
         }
         .background(Color.main20.ignoresSafeArea())
     }
@@ -58,11 +62,17 @@ struct MyPageBadgeView: View {
 
             VStack(spacing: 10) {
 
-                // TODO: 뱃지 url 맞춰서 수정 필요
-                Image(.badgeDefault)
+                KFImage(URL(string: viewModel.summaryBadgeUrl))
+                    .placeholder {
+                        RoundedRectangle(cornerRadius: 21.1)
+                            .fill(Color.white)
+                            .frame(width: 100, height: 100)
+                    }
                     .resizable()
-                    .scaledToFit()
+                    .scaledToFill()
                     .frame(width: 100, height: 100)
+                    .clipped()
+                    .cornerRadius(21.1)
 
                 Text(viewModel.summayTitle)
                     .font(.NotoSans_24_SB)

--- a/Totori/Presentation/MyPage/MyPageBadgeView.swift
+++ b/Totori/Presentation/MyPage/MyPageBadgeView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MyPageBadgeView: View {
 
+    let category: BadgeCategory
     @StateObject private var viewModel = MyPageBadgeViewModel()
 
     var body: some View {
@@ -41,6 +42,9 @@ struct MyPageBadgeView: View {
                 }
                 .padding(.horizontal, 20)
             }
+        }
+        .onAppear {
+            viewModel.fetchAll(category: category)
         }
         .background(Color.main20.ignoresSafeArea())
     }
@@ -80,8 +84,4 @@ struct MyPageBadgeView: View {
             .padding(.horizontal, 20)
         }
     }
-}
-
-#Preview {
-    MyPageBadgeView()
 }

--- a/Totori/Presentation/MyPage/MyPageBadgeViewModel.swift
+++ b/Totori/Presentation/MyPage/MyPageBadgeViewModel.swift
@@ -28,7 +28,7 @@ final class MyPageBadgeViewModel: ObservableObject {
     @Published var summaryTotalCount: Int = 10
     @Published var summarysuccessCount: Int = 4
     @Published var summaryProgress: CGFloat = 0.7
-    @Published var summaryBadgeUrl: Image = Image(.badgePurple)
+    @Published var summaryBadgeUrl: String = ""
     
     var progressText: String {
         "\(summarysuccessCount)/\(summaryTotalCount)"
@@ -42,12 +42,12 @@ final class MyPageBadgeViewModel: ObservableObject {
     private let badgeService = BadgeService()
     private var cancellables = Set<AnyCancellable>()
     
-    func fetchAll(category: BadgeCategory) {
-        fetchCategoryBadges(category: category)
+    func fetchAll(category: BadgeCategory, initialBadgeId: Int) {
+        fetchCategoryBadges(category: category, initialBadgeId: initialBadgeId)
     }
 
     // 특정 카테고리의 뱃지 리스트를 가져오기
-    func fetchCategoryBadges(category: BadgeCategory) {
+    func fetchCategoryBadges(category: BadgeCategory,initialBadgeId: Int) {
         isLoading = true
             
         badgeService.getCategoryBadges(category: category.rawValue)
@@ -62,20 +62,29 @@ final class MyPageBadgeViewModel: ObservableObject {
                 guard let self = self else { return }
                 
                 let category = BadgeCategory(rawValue: response.category) ?? .acorn
+                let currentCount = response.currentCount
                 
                 self.items = response.badges.map{
                     BadgeListItem(
                         id: $0.badgeId,
                         title: $0.name,
                         subtitle: category.getSubtitle(
-                            current: $0.level,
+                            current: currentCount,
                             target: $0.targetValue
                         ),
                         imageUrl: $0.imageUrl,
                         // TODO: progress response에 있으면 추가
-                        progress: $0.isAcquired ? 1.0 : 0.7,
+                        progress: $0.isAcquired ? 1.0 : (CGFloat(currentCount) / CGFloat($0.targetValue)),
                         isUnlocked: $0.isAcquired
                     )
+                }
+                
+                // 대표뱃지 설정
+                // TODO: totalCount, successCount 추가
+                if let selectedItem = items.first(where: { $0.id == initialBadgeId }) {
+                    self.summayTitle = selectedItem.title
+                    self.summaryProgress = selectedItem.progress
+                    self.summaryBadgeUrl = selectedItem.imageUrl
                 }
             }
             .store(in: &cancellables)

--- a/Totori/Presentation/MyPage/MyPageBadgeViewModel.swift
+++ b/Totori/Presentation/MyPage/MyPageBadgeViewModel.swift
@@ -33,18 +33,51 @@ final class MyPageBadgeViewModel: ObservableObject {
     var progressText: String {
         "\(summarysuccessCount)/\(summaryTotalCount)"
     }
+    
+    @Published var items: [BadgeListItem] = []
+    
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String? = nil
+    
+    private let badgeService = BadgeService()
+    private var cancellables = Set<AnyCancellable>()
+    
+    func fetchAll(category: BadgeCategory) {
+        fetchCategoryBadges(category: category)
+    }
 
-    // 달성 가까운 뱃지
-    @Published var closestBadgeTitle: String = "도토리 수집가"
-    @Published var closestBadgeSubtitle: String = "도토리 총 10개 모으기 (4/10)"
-    @Published var closestBadgeProgress: CGFloat = 0.4
-    @Published var closestBadgeUrl: String = ""
-
-    @Published var items: [BadgeListItem] = [
-        .init(id: 1, title: "첫 도토리 수확", subtitle: "도토리 총 10개 모으기 (4/10)", imageUrl: "", progress: 0.4, isUnlocked: false),
-        .init(id: 2, title: "도토리 초보수집가", subtitle: "도토리 총 10개 모으기 (4/10)", imageUrl: "", progress: 1, isUnlocked: true),
-        .init(id: 3, title: "도토리 수집가", subtitle: "도토리 총 10개 모으기 (4/10)", imageUrl: "", progress: 1, isUnlocked: true),
-        .init(id: 4, title: "도토리 베테랑", subtitle: "도토리 총 10개 모으기 (4/10)", imageUrl: "", progress: 0.8, isUnlocked: false),
-        .init(id: 5, title: "도토리 히어로", subtitle: "도토리 총 10개 모으기 (4/10)", imageUrl: "", progress: 1, isUnlocked: true)
-    ]
+    // 특정 카테고리의 뱃지 리스트를 가져오기
+    func fetchCategoryBadges(category: BadgeCategory) {
+        isLoading = true
+            
+        badgeService.getCategoryBadges(category: category.rawValue)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] completion in
+                self?.isLoading = false
+                if case .failure(let error) = completion {
+                    print("카테고리 뱃지 조회 실패: \(error.localizedDescription)")
+                    self?.errorMessage = error.localizedDescription
+                }
+            } receiveValue: { [weak self] response in
+                guard let self = self else { return }
+                
+                let category = BadgeCategory(rawValue: response.category) ?? .acorn
+                
+                self.items = response.badges.map{
+                    BadgeListItem(
+                        id: $0.badgeId,
+                        title: $0.name,
+                        subtitle: category.getSubtitle(
+                            current: $0.level,
+                            target: $0.targetValue
+                        ),
+                        imageUrl: $0.imageUrl,
+                        // TODO: progress response에 있으면 추가
+                        progress: $0.isAcquired ? 1.0 : 0.7,
+                        isUnlocked: $0.isAcquired
+                    )
+                }
+            }
+            .store(in: &cancellables)
+    }
 }

--- a/Totori/Presentation/MyPage/MyPageMainView.swift
+++ b/Totori/Presentation/MyPage/MyPageMainView.swift
@@ -62,6 +62,9 @@ struct MyPageMainView: View {
                 }
             }
             .background(.main20)
+            .onAppear {
+                viewModel.fetchAll()
+            }
             .navigationDestination(isPresented: $goConnect) {
                 ConnectView(viewModel: ConnectViewModel(role: .child))
             }

--- a/Totori/Presentation/MyPage/MyPageMainView.swift
+++ b/Totori/Presentation/MyPage/MyPageMainView.swift
@@ -14,7 +14,8 @@ struct MyPageMainView: View {
     @State private var showPopOver = false
     @State private var goBadgeList = false
     @State private var goConnect = false
-    @State private var selectedCategory: BadgeCategory?
+    @State private var selectedCategory: BadgeCategory? = nil
+    @State private var selectedBadgeId: Int? = nil
     
     private let columns: [GridItem] = Array(
         repeating: GridItem(.flexible(), spacing: 8),
@@ -50,7 +51,8 @@ struct MyPageMainView: View {
                                 BadgeGridCell(badge: badge)
                                     .onTapGesture {
                                         let category = BadgeCategory(rawValue: badge.category) ?? .acorn
-                                        selectedCategory = category
+                                        self.selectedCategory = category
+                                        self.selectedBadgeId = badge.id
                                     }
                             }
                         }
@@ -67,8 +69,10 @@ struct MyPageMainView: View {
                 ConnectView(viewModel: ConnectViewModel(role: .child))
             }
             .navigationDestination(item: $selectedCategory) { category in
-                MyPageBadgeView(category: category)
-                    .navigationBarBackButtonHidden(true)
+                if let category = selectedCategory, let id = selectedBadgeId {
+                    MyPageBadgeView(category: category, initialBadgeId: id)
+                        .navigationBarBackButtonHidden(true)
+                }
             }
             
             if showPopOver {

--- a/Totori/Presentation/MyPage/MyPageMainView.swift
+++ b/Totori/Presentation/MyPage/MyPageMainView.swift
@@ -14,6 +14,7 @@ struct MyPageMainView: View {
     @State private var showPopOver = false
     @State private var goBadgeList = false
     @State private var goConnect = false
+    @State private var selectedCategory: BadgeCategory?
     
     private let columns: [GridItem] = Array(
         repeating: GridItem(.flexible(), spacing: 8),
@@ -40,19 +41,16 @@ struct MyPageMainView: View {
                             progress: viewModel.progress,
                             imageUrl: viewModel.imageUrl,
                             onTap: {
-                                goBadgeList = true
+                                selectedCategory = viewModel.representativeCategory
                             }
                         )
-                        .navigationDestination(isPresented: $goBadgeList) {
-                            MyPageBadgeView()
-                                .navigationBarBackButtonHidden(true)
-                        }
                         
                         LazyVGrid(columns: columns, spacing: 8) {
                             ForEach(viewModel.badges) { badge in
                                 BadgeGridCell(badge: badge)
                                     .onTapGesture {
-                                        // TODO: 뱃지 상세/획득 팝업 등
+                                        let category = BadgeCategory(rawValue: badge.category) ?? .acorn
+                                        selectedCategory = category
                                     }
                             }
                         }
@@ -67,6 +65,10 @@ struct MyPageMainView: View {
             }
             .navigationDestination(isPresented: $goConnect) {
                 ConnectView(viewModel: ConnectViewModel(role: .child))
+            }
+            .navigationDestination(item: $selectedCategory) { category in
+                MyPageBadgeView(category: category)
+                    .navigationBarBackButtonHidden(true)
             }
             
             if showPopOver {

--- a/Totori/Presentation/MyPage/MyPageMainViewModel.swift
+++ b/Totori/Presentation/MyPage/MyPageMainViewModel.swift
@@ -43,10 +43,12 @@ final class MyPageMainViewModel: ObservableObject {
     @Published var errorMessage: String? = nil
     
     private let memberService = MemberService()
+    private let badgeService = BadgeService()
     private var cancellables = Set<AnyCancellable>()
     
     func fetchAll() {
         fetchAcornInfo()
+        fetchRepresentativeBadge()
     }
     
     // 도토리 및 유저 정보 가져오기
@@ -68,5 +70,31 @@ final class MyPageMainViewModel: ObservableObject {
                 self.totalAcorn = response.acorn
             }
             .store(in: &cancellables)
+    }
+    
+    // 대표 뱃지 정보 가져오기
+    func fetchRepresentativeBadge() {
+        badgeService.getMyRepresentativeBadge()
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                if case .failure(let error) = completion {
+                    print("대표 뱃지 조회 실패: \(error.localizedDescription)")
+                }
+            } receiveValue: { [weak self] response in
+                self?.applyRepresentativeBadge(response)
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func applyRepresentativeBadge(_ dto: MemberBadgeResponseDTO) {
+        let badge = dto.badgeResponseDto
+        let category = BadgeCategory(rawValue: badge.category ?? "") ?? .acorn
+        self.badgeSubTitle = category.getSubtitle(
+                current: badge.level,
+                target: badge.targetValue
+            )
+        self.badgeTitle = badge.name
+        self.imageUrl = badge.imageUrl
+        self.progress = 0.8
     }
 }

--- a/Totori/Presentation/MyPage/MyPageMainViewModel.swift
+++ b/Totori/Presentation/MyPage/MyPageMainViewModel.swift
@@ -74,21 +74,19 @@ final class MyPageMainViewModel: ObservableObject {
                     print("대표 뱃지 조회 실패: \(error.localizedDescription)")
                 }
             } receiveValue: { [weak self] response in
-                self?.applyRepresentativeBadge(response)
+                guard let self = self else { return }
+                
+                let badge = response.badgeResponseDto
+                let category = BadgeCategory(rawValue: badge.category ?? "") ?? .acorn
+                self.badgeSubTitle = category.getSubtitle(
+                        current: badge.level,
+                        target: badge.targetValue
+                    )
+                self.badgeTitle = badge.name
+                self.imageUrl = badge.imageUrl
+                self.progress = 0.8
             }
             .store(in: &cancellables)
-    }
-    
-    private func applyRepresentativeBadge(_ dto: MemberBadgeResponseDTO) {
-        let badge = dto.badgeResponseDto
-        let category = BadgeCategory(rawValue: badge.category ?? "") ?? .acorn
-        self.badgeSubTitle = category.getSubtitle(
-                current: badge.level,
-                target: badge.targetValue
-            )
-        self.badgeTitle = badge.name
-        self.imageUrl = badge.imageUrl
-        self.progress = 0.8
     }
     
     // 전체 획득 뱃지 리스트 가져오기
@@ -100,19 +98,17 @@ final class MyPageMainViewModel: ObservableObject {
                     print("전체 뱃지 조회 실패: \(error.localizedDescription)")
                 }
             } receiveValue: { [weak self] response in
-                self?.applyBadgeList(response)
+                guard let self = self else { return }
+                
+                // TODO: isUnlocked response에 추가되면 수정
+                self.badges = response.map {
+                    BadgeItem(
+                        id: $0.badgeResponseDto.id,
+                        isUnlocked: true,
+                        imageUrl: $0.badgeResponseDto.imageUrl
+                    )
+                }
             }
             .store(in: &cancellables)
-    }
-    
-    // TODO: isUnlocked response에 추가되면 수정
-    private func applyBadgeList(_ list: [MemberBadgeResponseDTO]) {
-        self.badges = list.map {
-            BadgeItem(
-                id: $0.badgeResponseDto.id,
-                isUnlocked: true,
-                imageUrl: $0.badgeResponseDto.imageUrl
-            )
-        }
     }
 }

--- a/Totori/Presentation/MyPage/MyPageMainViewModel.swift
+++ b/Totori/Presentation/MyPage/MyPageMainViewModel.swift
@@ -8,12 +8,16 @@
 import Combine
 import SwiftUI
 
+// MARK: - Model
+
 struct BadgeItem: Identifiable, Equatable {
     let id: Int
     let isUnlocked: Bool
     let imageUrl: String
     let progress: CGFloat
 }
+
+// MARK: - ViewModel
 
 final class MyPageMainViewModel: ObservableObject {
     @Published var userName: String = "김밤톨"
@@ -33,4 +37,36 @@ final class MyPageMainViewModel: ObservableObject {
         .init(id: 5, isUnlocked: true,  imageUrl: "badge_5", progress: 0.8),
         .init(id: 6, isUnlocked: false, imageUrl: "badge_6", progress: 1)
     ]
+    
+    // status
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String? = nil
+    
+    private let memberService = MemberService()
+    private var cancellables = Set<AnyCancellable>()
+    
+    func fetchAll() {
+        fetchAcornInfo()
+    }
+    
+    // 도토리 및 유저 정보 가져오기
+    func fetchAcornInfo() {
+        isLoading = true
+            
+        memberService.getAcorn()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] completion in
+                self?.isLoading = false
+                if case .failure(let error) = completion {
+                    print("마이페이지 정보 조회 실패: \(error.localizedDescription)")
+                    self?.errorMessage = error.localizedDescription
+                }
+            } receiveValue: { [weak self] response in
+                guard let self = self else { return }
+                
+                self.userName = response.name
+                self.totalAcorn = response.acorn
+            }
+            .store(in: &cancellables)
+    }
 }

--- a/Totori/Presentation/MyPage/MyPageMainViewModel.swift
+++ b/Totori/Presentation/MyPage/MyPageMainViewModel.swift
@@ -14,6 +14,7 @@ struct BadgeItem: Identifiable, Equatable {
     let id: Int
     let isUnlocked: Bool
     let imageUrl: String
+    let category: String
 }
 
 // MARK: - ViewModel
@@ -27,6 +28,7 @@ final class MyPageMainViewModel: ObservableObject {
     @Published var badgeSubTitle: String = "도토리 총 10개 모으기 (4/10)"
     @Published var imageUrl: String? = nil
     @Published var progress: CGFloat = 0.7
+    @Published var representativeCategory: BadgeCategory = .acorn
 
     @Published var badges: [BadgeItem] = []
     
@@ -77,7 +79,9 @@ final class MyPageMainViewModel: ObservableObject {
                 guard let self = self else { return }
                 
                 let badge = response.badgeResponseDto
-                let category = BadgeCategory(rawValue: badge.category ?? "") ?? .acorn
+                let category = BadgeCategory(rawValue: badge.category) ?? .acorn
+                
+                self.representativeCategory = category
                 self.badgeSubTitle = category.getSubtitle(
                         current: badge.level,
                         target: badge.targetValue
@@ -105,7 +109,8 @@ final class MyPageMainViewModel: ObservableObject {
                     BadgeItem(
                         id: $0.badgeResponseDto.id,
                         isUnlocked: true,
-                        imageUrl: $0.badgeResponseDto.imageUrl
+                        imageUrl: $0.badgeResponseDto.imageUrl,
+                        category: $0.badgeResponseDto.category
                     )
                 }
             }

--- a/Totori/Presentation/MyPage/MyPageMainViewModel.swift
+++ b/Totori/Presentation/MyPage/MyPageMainViewModel.swift
@@ -14,7 +14,6 @@ struct BadgeItem: Identifiable, Equatable {
     let id: Int
     let isUnlocked: Bool
     let imageUrl: String
-    let progress: CGFloat
 }
 
 // MARK: - ViewModel
@@ -29,14 +28,7 @@ final class MyPageMainViewModel: ObservableObject {
     @Published var imageUrl: String? = nil
     @Published var progress: CGFloat = 0.7
 
-    @Published var badges: [BadgeItem] = [
-        .init(id: 1, isUnlocked: true,  imageUrl: "badge_1", progress: 1),
-        .init(id: 2, isUnlocked: false, imageUrl: "badge_2", progress: 0.3),
-        .init(id: 3, isUnlocked: true,  imageUrl: "badge_3", progress: 1),
-        .init(id: 4, isUnlocked: true,  imageUrl: "badge_4", progress: 1),
-        .init(id: 5, isUnlocked: true,  imageUrl: "badge_5", progress: 0.8),
-        .init(id: 6, isUnlocked: false, imageUrl: "badge_6", progress: 1)
-    ]
+    @Published var badges: [BadgeItem] = []
     
     // status
     @Published var isLoading: Bool = false
@@ -49,6 +41,7 @@ final class MyPageMainViewModel: ObservableObject {
     func fetchAll() {
         fetchAcornInfo()
         fetchRepresentativeBadge()
+        fetchBadgeList()
     }
     
     // 도토리 및 유저 정보 가져오기
@@ -96,5 +89,30 @@ final class MyPageMainViewModel: ObservableObject {
         self.badgeTitle = badge.name
         self.imageUrl = badge.imageUrl
         self.progress = 0.8
+    }
+    
+    // 전체 획득 뱃지 리스트 가져오기
+    func fetchBadgeList() {
+        badgeService.getMyAllBadges()
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                if case .failure(let error) = completion {
+                    print("전체 뱃지 조회 실패: \(error.localizedDescription)")
+                }
+            } receiveValue: { [weak self] response in
+                self?.applyBadgeList(response)
+            }
+            .store(in: &cancellables)
+    }
+    
+    // TODO: isUnlocked response에 추가되면 수정
+    private func applyBadgeList(_ list: [MemberBadgeResponseDTO]) {
+        self.badges = list.map {
+            BadgeItem(
+                id: $0.badgeResponseDto.id,
+                isUnlocked: true,
+                imageUrl: $0.badgeResponseDto.imageUrl
+            )
+        }
     }
 }


### PR DESCRIPTION
## 📟 연결된 이슈
- #59
<br>

## 🍎 작업 내용
- 메인페이지에서 본인 정보, 현재 획득한 뱃지 리스트 api 연결
- 메인페이지에서 클릭한 뱃지를 기반으로, 해당 카테고리의 뱃지 리스트 api 연결
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 화면2 |
|:---------:|:-------------:|:-------------:|
| 기능1 |<img width="345" height="630" alt="image" src="https://github.com/user-attachments/assets/b06a1683-9abe-4997-a7c0-ce479a8b4c07" />|<img width="348" height="658" alt="image" src="https://github.com/user-attachments/assets/d17dbbcc-77ca-4e31-8657-9f58b9bad007" />|
<br>

## 💬 리뷰 코멘트
- 지금 메인페이지 정보 불러올때, 총 읽은 이야기 권수 불러오는 부분, 대표뱃지 불러올 때 몇프로 달성했는지 들고 올 수 있는 현재값이 백엔드 api에서 수정되면 추가해서 완료하도록 하겠습니다.
- 아직 헷갈려서 그러는데..ㅎㅎ 메인페이지 하단에 나오는 부분 "/api/badges/my"에 해당하는 부분은 획득이 완료된 뱃지들만 나오는게 맞나요 아니면 곧 획득 예정인 것들도 나오나요? 지금 연결해보니까 전자로 나오는 것 같은데, 지금 디자인상으로는 미획득인 뱃지들도 하단에 나와야하는 것 같아서 여쭤봅니다!