### PR TITLE
[network] #67 동화 상세 조회 api 연결

### DIFF
--- a/Totori/Network/API/TotoriAPI.swift
+++ b/Totori/Network/API/TotoriAPI.swift
@@ -22,6 +22,7 @@ enum TotoriAPI {
     case mainStatus
     case bookList(page: Int, size: Int)
     case makeBook(audioURL: URL)
+    case bookDetail(bookId: Int)
     
     //member
     case acorn
@@ -53,6 +54,8 @@ extension TotoriAPI: BaseTargetType {
         case .bookList:
             return "/api/books"
         case .makeBook: return "/api/books/make"
+        case .bookDetail(let bookId):
+            return "/api/books/\(bookId)"
             
             //member
         case .acorn:
@@ -72,7 +75,7 @@ extension TotoriAPI: BaseTargetType {
         switch self {
         case .login, .signUp, .generateBook, .reissue, .attendance, .makeBook:
             return .post
-        case .mainStatus, .bookList, .acorn, .myRepresentativeBadge, .myAllBadges, .categoryBadges:
+        case .mainStatus, .bookList, .acorn, .myRepresentativeBadge, .myAllBadges, .categoryBadges, .bookDetail:
             return .get
         }
     }
@@ -94,6 +97,8 @@ extension TotoriAPI: BaseTargetType {
                 parameters: ["page": page, "size": size],
                 encoding: URLEncoding.queryString
             )
+        case .bookDetail:
+            return .requestPlain
         case .attendance:
             return .requestPlain
         case .makeBook(let audioURL):

--- a/Totori/Network/StoryBook/DTO/BookDetailDTO.swift
+++ b/Totori/Network/StoryBook/DTO/BookDetailDTO.swift
@@ -1,0 +1,34 @@
+//
+//  BookDetailDTO.swift
+//  Totori
+//
+//  Created by 정윤아 on 5/15/26.
+//
+
+struct BookDetailResponseDTO: Decodable {
+    let cover: BookCoverDTO
+    let pages: [BookPageDTO]
+}
+
+struct BookCoverDTO: Decodable {
+    let bookId: Int
+    let title: String
+    let coverImageUrl: String
+    let acornCount: Int
+    let currentPage: Int
+    let totalPage: Int
+    let progress: Double
+}
+
+struct BookPageDTO: Decodable {
+    let pageId: Int
+    let pageOrder: Int
+    let sentences: [BookSentenceDTO]
+    let imageUrl: String
+}
+
+struct BookSentenceDTO: Decodable {
+    let text: String
+    let audioUrl: String?
+    let durationMs: Int?
+}

--- a/Totori/Network/StoryBook/Service/BookDetailService.swift
+++ b/Totori/Network/StoryBook/Service/BookDetailService.swift
@@ -16,11 +16,14 @@ class BookDetailService {
         return networkService.request(.bookDetail(bookId: bookId), responseType: BookDetailResponseDTO.self)
             .handleEvents(
                 receiveOutput: { response in
+                    print("🌐 BookDetailService - 응답 수신: \(response.cover.title)")
                 },
                 receiveCompletion: { completion in
                     switch completion {
                     case .finished:
+                        print("🌐 BookDetailService - 완료")
                     case .failure(let error):
+                        print("🌐 BookDetailService - 에러: \(error)")
                     }
                 }
             )

--- a/Totori/Network/StoryBook/Service/BookDetailService.swift
+++ b/Totori/Network/StoryBook/Service/BookDetailService.swift
@@ -1,0 +1,29 @@
+//
+//  BookDetailService.swift
+//  Totori
+//
+//  Created by 정윤아 on 5/15/26.
+//
+
+import Combine
+import Foundation
+
+class BookDetailService {
+    private let networkService = BaseService<TotoriAPI>()
+    
+    func fetchBookDetail(bookId: Int) -> AnyPublisher<BookDetailResponseDTO, NetworkError> {
+        print("🌐 BookDetailService - API 요청 시작: bookId=\(bookId)")
+        return networkService.request(.bookDetail(bookId: bookId), responseType: BookDetailResponseDTO.self)
+            .handleEvents(
+                receiveOutput: { response in
+                },
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                    case .failure(let error):
+                    }
+                }
+            )
+            .eraseToAnyPublisher()
+    }
+}

--- a/Totori/Presentation/Main/MainView.swift
+++ b/Totori/Presentation/Main/MainView.swift
@@ -83,17 +83,8 @@ struct MainView: View {
                             .buttonStyle(.plain)
                             
                             ForEach(viewModel.bookItems) { item in
-                                let mockBookData = BookGenerateResponseDTO(
-                                    bookId: item.id,
-                                    title: item.title,
-                                    totalPages: 10,
-                                    coverImagePrompt: nil,
-                                    coverImageUrl: item.coverURL ?? "https://picsum.photos/id/10/800/1200",
-                                    pages: []
-                                )
-                                
                                 NavigationLink(
-                                    destination: BookInfoView(bookData: mockBookData)
+                                    destination: BookInfoView(bookId: item.id)
                                         .navigationBarBackButtonHidden(true)
                                 ) {
                                     StoryBookView(type: item.type)

--- a/Totori/Presentation/ReadStoryBook/ReadStoryBookSource.swift
+++ b/Totori/Presentation/ReadStoryBook/ReadStoryBookSource.swift
@@ -1,0 +1,11 @@
+//
+//  ReadStoryBookSource.swift
+//  Totori
+//
+//  Created by 정윤아 on 5/15/26.
+//
+
+enum ReadStoryBookSource {
+    case generated(BookGenerateResponseDTO)
+    case detail(BookDetailResponseDTO)
+}

--- a/Totori/Presentation/ReadStoryBook/View/BookInfoView.swift
+++ b/Totori/Presentation/ReadStoryBook/View/BookInfoView.swift
@@ -12,7 +12,21 @@ import Kingfisher
 struct BookInfoView: View {
     @StateObject private var viewModel = BookInfoViewModel()
     
-    let bookData: BookGenerateResponseDTO
+    private enum Source {
+        case generated(BookGenerateResponseDTO)
+        case detail(Int) // bookId
+    }
+    private let source: Source
+    
+    // 생성 후 진입
+    init(bookData: BookGenerateResponseDTO) {
+        self.source = .generated(bookData)
+    }
+    
+    // 상세 조회 후 진입
+    init(bookId: Int) {
+        self.source = .detail(bookId)
+    }
     
     var body: some View {
         ZStack {
@@ -78,11 +92,18 @@ struct BookInfoView: View {
             }
         }
         .onAppear {
-            viewModel.setupData(with: bookData)
+            switch source {
+            case .generated(let bookData):
+                print("🟢 generated 경로")
+                viewModel.setupData(with: bookData)
+            case .detail(let bookId):
+                print("🟢 detail 경로 - bookId: \(bookId)")
+                viewModel.fetchDetail(bookId: bookId)
+            }
         }
         .navigationDestination(isPresented: $viewModel.navigateToReadStoryBook) {
-            if let data = viewModel.bookData {
-                ReadStoryBookView(bookData: data)
+            if let source = viewModel.readSource {
+                ReadStoryBookView(source: source)
                     .navigationBarBackButtonHidden(true)
             }
         }

--- a/Totori/Presentation/ReadStoryBook/View/ReadStoryBookView.swift
+++ b/Totori/Presentation/ReadStoryBook/View/ReadStoryBookView.swift
@@ -13,10 +13,22 @@ struct ReadStoryBookView: View {
     @StateObject private var viewModel = ReadStoryBookViewModel()
     @Environment(\.dismiss) private var dismiss
     
-    let bookData: BookGenerateResponseDTO
-    
     @State private var showModal: Bool = false
     @State private var navigateToStart: Bool = false
+    
+    private let source: ReadStoryBookSource
+    
+    init(bookData: BookGenerateResponseDTO) {
+        self.source = .generated(bookData)
+    }
+    
+    init(bookDetail: BookDetailResponseDTO) {
+        self.source = .detail(bookDetail)
+    }
+    
+    init(source: ReadStoryBookSource) {
+        self.source = source
+    }
     
     var body: some View {
         ZStack {
@@ -64,7 +76,12 @@ struct ReadStoryBookView: View {
             }
         }
         .onAppear {
-            viewModel.setUpData(bookData: bookData)
+            switch source {
+            case .generated(let bookData):
+                viewModel.setUpData(bookData: bookData)
+            case .detail(let bookDetail):
+                viewModel.setUpData(bookDetail: bookDetail)
+            }
         }
         .navigationDestination(isPresented: $navigateToStart) {
             MainView()

--- a/Totori/Presentation/ReadStoryBook/ViewModel/BookInfoViewModel.swift
+++ b/Totori/Presentation/ReadStoryBook/ViewModel/BookInfoViewModel.swift
@@ -9,15 +9,23 @@ import Combine
 import SwiftUI
 
 class BookInfoViewModel: ObservableObject {
-    @Published var bookData: BookGenerateResponseDTO? = nil
+    
+    // MARK: - Published
     
     @Published var bookTitle: String = ""
     @Published var coverImageUrl: String = ""
     @Published var totalPages: Int = 0
     @Published var readPages: Int = 0
     @Published var acornCount: Int = 0
-    
     @Published var navigateToReadStoryBook: Bool = false
+    @Published var readSource: ReadStoryBookSource? = nil
+    
+    // MARK: - Data Source
+    
+    private var generatedBookData: BookGenerateResponseDTO? = nil
+    private var detailBookData: BookDetailResponseDTO? = nil
+    
+    // MARK: - Computed
     
     var progressPercentage: Double {
         guard totalPages > 0 else { return 0.0 }
@@ -28,16 +36,45 @@ class BookInfoViewModel: ObservableObject {
         return "\(readPages)/\(totalPages)"
     }
     
-    // MARK: - Actions
+    // MARK: - Set up
     
     func setupData(with data: BookGenerateResponseDTO) {
-        self.bookData = data
-        self.bookTitle = data.title
-        
-        self.coverImageUrl = data.coverImageUrl
-        self.totalPages = data.pages.count
-        self.readPages = 0
+        generatedBookData = data
+        bookTitle = data.title
+        coverImageUrl = data.coverImageUrl
+        totalPages = data.pages.count
+        readPages = 0
+        acornCount = 0
+        readSource = .generated(data)
     }
+    
+    func fetchDetail(bookId: Int) {
+        bookDetailService.fetchBookDetail(bookId: bookId)
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                switch completion {
+                case .failure(let error):
+                    print("❌ 실패: \(error)")
+                case .finished:
+                    print("✅ 완료")
+                }
+            } receiveValue: { [weak self] response in
+                self?.applyDetailData(response)
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func applyDetailData(_ data: BookDetailResponseDTO) {
+        detailBookData = data
+        bookTitle = data.cover.title
+        coverImageUrl = data.cover.coverImageUrl
+        totalPages = data.cover.totalPage
+        readPages = data.cover.currentPage
+        acornCount = data.cover.acornCount
+        readSource = .detail(data)
+    }
+    
+    // MARK: - Actions
     
     func tapBackButton() {
         print("뒤로 가기 버튼 탭")
@@ -51,4 +88,9 @@ class BookInfoViewModel: ObservableObject {
         print("이야기 읽기 버튼 탭")
         navigateToReadStoryBook = true
     }
+    
+    // MARK: - Private
+    
+    private var cancellables = Set<AnyCancellable>()
+    private let bookDetailService = BookDetailService()
 }

--- a/Totori/Presentation/ReadStoryBook/ViewModel/ReadStoryBookViewModel.swift
+++ b/Totori/Presentation/ReadStoryBook/ViewModel/ReadStoryBookViewModel.swift
@@ -30,11 +30,34 @@ class ReadStoryBookViewModel: ObservableObject {
     
     init() {}
     
+    // BookGenerateResponseDTO 버전
     func setUpData(bookData: BookGenerateResponseDTO) {
         var flatList: [DisplayPage] = []
         var globalIdx = 0
         
         let sortedPages = bookData.pages.sorted { $0.pageOrder < $1.pageOrder }
+        
+        for page in sortedPages {
+            for sentence in page.sentences {
+                let displayPage = DisplayPage(
+                    globalIndex: globalIdx,
+                    imageUrl: page.imageUrl,
+                    text: sentence.text,
+                    audioUrl: sentence.audioUrl
+                )
+                flatList.append(displayPage)
+                globalIdx += 1
+            }
+        }
+        self.displayPages = flatList
+    }
+
+    // BookDetailResponseDTO 버전
+    func setUpData(bookDetail: BookDetailResponseDTO) {
+        var flatList: [DisplayPage] = []
+        var globalIdx = 0
+        
+        let sortedPages = bookDetail.pages.sorted { $0.pageOrder < $1.pageOrder }
         
         for page in sortedPages {
             for sentence in page.sentences {


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #67
<br>

## 🍎 작업 내용
동화 상세 조회 api를 연결하였습니다. 
기존 bookGenerateResponseDto랑 구조가 동일하여서 재사용하려고 했는데요..... 이게 동화를 생성하고 동화 낭독 화면으로 이동하는 것과 동화낭독화면으로 바로 이동하는것이 구분되어야할 것 같아서 별도로 dto를 구성하였습니다. 
분기처리를 하면서 에러가 좀 나서 로그용 이모티콘이 조금 많습니다....

그리고 동화 tts들어봤는데 더 느리게 해야할 것 같아요... 말이 빨라.....
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 기능1 |<img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 - 2026-05-15 at 03 42 35" src="https://github.com/user-attachments/assets/b466ed08-4529-4f21-b898-534880faf88d" />|
<br>

## 💬 리뷰 코멘트
