### PR TITLE
[network] #69 퀴즈 api 연결

### DIFF
--- a/Totori/Network/API/TotoriAPI.swift
+++ b/Totori/Network/API/TotoriAPI.swift
@@ -25,6 +25,9 @@ enum TotoriAPI {
     case bookDetail(bookId: Int)
     case uploadReadingAudio(bookId: Int, sentenceNum: Int, audioURL: URL)
     
+    //quiz
+    case makeQuiz(bookId: Int)
+    
     //member
     case acorn
     
@@ -68,6 +71,10 @@ extension TotoriAPI: BaseTargetType {
             return "/api/books/\(bookId)"
         case .uploadReadingAudio(let bookId, let sentenceNum, _):
             return "/api/books/\(bookId)/reading/\(sentenceNum)"
+            
+            //quiz
+        case .makeQuiz:
+            return "/api/quiz/generate"
             
             //member
         case .acorn:
@@ -168,6 +175,11 @@ extension TotoriAPI: BaseTargetType {
             return .requestPlain
         case .connectParent(let param):
             return .requestJSONEncodable(param)
+        case .makeQuiz(let bookId):
+            return .requestParameters(
+                parameters: ["bookId": bookId],
+                encoding: URLEncoding.queryString
+            )
         }
     }
     

--- a/Totori/Network/API/TotoriAPI.swift
+++ b/Totori/Network/API/TotoriAPI.swift
@@ -109,7 +109,7 @@ extension TotoriAPI: BaseTargetType {
     
     var method: Moya.Method {
         switch self {
-        case .login, .signUp, .generateBook, .reissue, .attendance, .makeBook, .uploadReadingAudio, .connectCode, .connectParent:
+        case .login, .signUp, .generateBook, .reissue, .attendance, .makeBook, .uploadReadingAudio, .connectCode, .connectParent, .makeQuiz, .checkQuiz:
             return .post
         case .mainStatus, .bookList, .acorn, .myRepresentativeBadge, .myAllBadges, .categoryBadges, .bookDetail, .weeklyReport, .totalReport, .weeklyBook:
             return .get

--- a/Totori/Network/API/TotoriAPI.swift
+++ b/Totori/Network/API/TotoriAPI.swift
@@ -27,6 +27,7 @@ enum TotoriAPI {
     
     //quiz
     case makeQuiz(bookId: Int)
+    case checkQuiz(quizId: Int, audioURL: URL, originalQuiz: String)
     
     //member
     case acorn
@@ -75,6 +76,8 @@ extension TotoriAPI: BaseTargetType {
             //quiz
         case .makeQuiz:
             return "/api/quiz/generate"
+        case .checkQuiz(let quizId, _, _):
+            return "/api/quiz/\(quizId)/check"
             
             //member
         case .acorn:
@@ -180,6 +183,18 @@ extension TotoriAPI: BaseTargetType {
                 parameters: ["bookId": bookId],
                 encoding: URLEncoding.queryString
             )
+        case .checkQuiz(_, let audioURL, let originalQuiz):
+            let audioData = MultipartFormData(
+                provider: .file(audioURL),
+                name: "audio",
+                fileName: audioURL.lastPathComponent,
+                mimeType: "audio/m4a"
+            )
+            let quizData = MultipartFormData(
+                provider: .data(originalQuiz.data(using: .utf8)!),
+                name: "original_quiz"
+            )
+            return .uploadMultipart([audioData, quizData])
         }
     }
     

--- a/Totori/Network/Quiz/DTO/QuizResponseDTO.swift
+++ b/Totori/Network/Quiz/DTO/QuizResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  QuizResponseDTO.swift
+//  Totori
+//
+//  Created by 정윤아 on 5/15/26.
+//
+
+import Foundation
+ 
+struct QuizResponseDTO: Decodable {
+    let quizId: Int
+    let quizItems: [String]
+}

--- a/Totori/Network/Quiz/DTO/QuizResponseDTO.swift
+++ b/Totori/Network/Quiz/DTO/QuizResponseDTO.swift
@@ -11,3 +11,9 @@ struct QuizResponseDTO: Decodable {
     let quizId: Int
     let quizItems: [String]
 }
+
+struct QuizCheckResponseDTO: Decodable {
+    let isCorrect: Bool
+    let rewarded: Bool
+    let currentAcorn: Int
+}

--- a/Totori/Network/Quiz/Service/QuizService.swift
+++ b/Totori/Network/Quiz/Service/QuizService.swift
@@ -17,4 +17,11 @@ final class QuizService {
             responseType: QuizResponseDTO.self
         )
     }
+    
+    func checkQuiz(quizId: Int, audioURL: URL, originalQuiz: String) -> AnyPublisher<QuizCheckResponseDTO, NetworkError> {
+        return networkService.request(
+            .checkQuiz(quizId: quizId, audioURL: audioURL, originalQuiz: originalQuiz),
+            responseType: QuizCheckResponseDTO.self
+        )
+    }
 }

--- a/Totori/Network/Quiz/Service/QuizService.swift
+++ b/Totori/Network/Quiz/Service/QuizService.swift
@@ -1,0 +1,20 @@
+//
+//  QuizService.swift
+//  Totori
+//
+//  Created by 정윤아 on 5/15/26.
+//
+
+import Combine
+import Foundation
+ 
+final class QuizService {
+    private let networkService = BaseService<TotoriAPI>()
+ 
+    func generateQuiz(bookId: Int) -> AnyPublisher<QuizResponseDTO, NetworkError> {
+        return networkService.request(
+            .makeQuiz(bookId: bookId),
+            responseType: QuizResponseDTO.self
+        )
+    }
+}

--- a/Totori/Network/Quiz/Service/QuizService.swift
+++ b/Totori/Network/Quiz/Service/QuizService.swift
@@ -11,7 +11,7 @@ import Foundation
 final class QuizService {
     private let networkService = BaseService<TotoriAPI>()
  
-    func generateQuiz(bookId: Int) -> AnyPublisher<QuizResponseDTO, NetworkError> {
+    func makeQuiz(bookId: Int) -> AnyPublisher<QuizResponseDTO, NetworkError> {
         return networkService.request(
             .makeQuiz(bookId: bookId),
             responseType: QuizResponseDTO.self

--- a/Totori/Presentation/Quiz/WordLearningView.swift
+++ b/Totori/Presentation/Quiz/WordLearningView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 struct WordLearningView: View {
 
     let successQuizCount: Int
+    let onComplete: () -> Void
 
-    // MARK: - State
     @StateObject private var viewModel: WordViewModel
 
     @State private var selectedID: String? = nil
@@ -20,92 +20,94 @@ struct WordLearningView: View {
 
     // MARK: - Init
 
-    init(successQuizCount: Int, bookId: Int) {
+    init(successQuizCount: Int, bookId: Int, onComplete: @escaping () -> Void) {
         self.successQuizCount = successQuizCount
+        self.onComplete = onComplete
         _viewModel = StateObject(wrappedValue: WordViewModel(bookId: bookId))
     }
 
     // MARK: - Body
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                VStack(spacing: 0) {
+        ZStack {
+            VStack(spacing: 0) {
 
-                    header(
-                        name: viewModel.userName,
-                        profileUrl: viewModel.profileUrl,
-                        acornAmount: viewModel.acornCount,
-                        progress: viewModel.progress
-                    )
+                header(
+                    name: viewModel.userName,
+                    profileUrl: viewModel.profileUrl,
+                    acornAmount: viewModel.acornCount,
+                    progress: viewModel.progress
+                )
+                .padding(.horizontal, 20)
+
+                Spacer().frame(height: 60)
+
+                Text("먼저, 단어를 들어보자!")
+                    .font(.NotoSans_24_SB)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 20)
 
-                    Spacer().frame(height: 60)
+                Spacer().frame(height: 40)
 
-                    Text("먼저, 단어를 들어보자!")
-                        .font(.NotoSans_24_SB)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, 20)
-
-                    Spacer().frame(height: 40)
-
-                    // 단어 리스트 or 로딩
-                    if viewModel.isLoading {
-                        Spacer()
-                        ProgressView("단어를 불러오는 중...")
+                if viewModel.isLoading {
+                    Spacer()
+                    ProgressView("단어를 불러오는 중...")
+                        .font(.NotoSans_24_R)
+                    Spacer()
+                } else if let error = viewModel.errorMessage {
+                    Spacer()
+                    VStack(spacing: 16) {
+                        Text(error)
                             .font(.NotoSans_24_R)
-                        Spacer()
-                    } else if let error = viewModel.errorMessage {
-                        Spacer()
-                        VStack(spacing: 16) {
-                            Text(error)
-                                .font(.NotoSans_24_R)
-                                .foregroundColor(.textGray)
-                            Button("다시 시도") {
-                                viewModel.fetchQuiz()
-                            }
-                            .font(.NotoSans_24_SB)
-                            .foregroundColor(.point)
+                            .foregroundColor(.textGray)
+                        Button("다시 시도") {
+                            viewModel.fetchQuiz()
                         }
-                        Spacer()
-                    } else {
-                        VStack(spacing: 20) {
-                            ForEach(viewModel.words, id: \.self) { item in
-                                wordRow(
-                                    title: item,
-                                    isSelected: selectedID == item,
-                                    isPlaying: (selectedID == item) && isPlaying,
-                                    onTap: { handleTap(itemID: item) }
-                                )
-                            }
-                        }
-                        .padding(.horizontal, 20)
-
-                        Spacer()
-
-                        AcornRewards(count: successQuizCount)
-
-                        Spacer()
-
-                        CTAButton(title: "다음", type: .purple) {
-                            viewModel.setupQuiz()
-                            isNavigatingToQuiz = true
-                        }
-                        .padding(.horizontal, 20)
-                        .padding(.bottom, 60)
+                        .font(.NotoSans_24_SB)
+                        .foregroundColor(.point)
                     }
+                    Spacer()
+                } else {
+                    VStack(spacing: 20) {
+                        ForEach(viewModel.words, id: \.self) { item in
+                            wordRow(
+                                title: item,
+                                isSelected: selectedID == item,
+                                isPlaying: (selectedID == item) && isPlaying,
+                                onTap: { handleTap(itemID: item) }
+                            )
+                        }
+                    }
+                    .padding(.horizontal, 20)
+
+                    Spacer()
+
+                    AcornRewards(count: successQuizCount)
+
+                    Spacer()
+
+                    CTAButton(title: "다음", type: .purple) {
+                        viewModel.setupQuiz()
+                        isNavigatingToQuiz = true
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 60)
                 }
-                .background(Color.white.ignoresSafeArea())
             }
-            .onAppear {
+            .background(Color.white.ignoresSafeArea())
+        }
+        .onAppear {
+            if viewModel.words.isEmpty {
                 viewModel.fetchQuiz()
             }
-            .navigationDestination(isPresented: $isNavigatingToQuiz) {
-                WordQuizRepeatView(
-                    successQuizCount: successQuizCount,
-                    viewModel: viewModel
-                )
-            }
+            // 콜백 연결
+            viewModel.onQuizCompleted = onComplete
+        }
+        .navigationDestination(isPresented: $isNavigatingToQuiz) {
+            WordQuizRepeatView(
+                successQuizCount: successQuizCount,
+                viewModel: viewModel
+            )
         }
     }
 

--- a/Totori/Presentation/Quiz/WordLearningView.swift
+++ b/Totori/Presentation/Quiz/WordLearningView.swift
@@ -12,66 +12,94 @@ struct WordLearningView: View {
     let successQuizCount: Int
 
     // MARK: - State
-    @StateObject private var viewModel = WordViewModel()
+    @StateObject private var viewModel: WordViewModel
 
     @State private var selectedID: String? = nil
     @State private var isPlaying: Bool = false
-    
     @State private var isNavigatingToQuiz: Bool = false
 
+    // MARK: - Init
+
+    init(successQuizCount: Int, bookId: Int) {
+        self.successQuizCount = successQuizCount
+        _viewModel = StateObject(wrappedValue: WordViewModel(bookId: bookId))
+    }
+
+    // MARK: - Body
+
     var body: some View {
-        NavigationStack{
-            VStack(spacing: 0) {
+        NavigationStack {
+            ZStack {
+                VStack(spacing: 0) {
 
-                // 헤더 (칩 + 프로그레스바)
-                header(
-                    name: viewModel.userName,
-                    profileUrl: viewModel.profileUrl,
-                    acornAmount: viewModel.acornCount,
-                    progress: viewModel.progress
-                )
-                .padding(.horizontal, 20)
-
-                Spacer().frame(height: 60)
-
-                // 타이틀
-                Text("먼저, 단어를 들어보자!")
-                    .font(.NotoSans_24_SB)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    header(
+                        name: viewModel.userName,
+                        profileUrl: viewModel.profileUrl,
+                        acornAmount: viewModel.acornCount,
+                        progress: viewModel.progress
+                    )
                     .padding(.horizontal, 20)
 
-                Spacer().frame(height: 40)
+                    Spacer().frame(height: 60)
 
-                // 단어 리스트
-                VStack(spacing: 20) {
-                    ForEach(viewModel.words, id: \.self) { item in
-                        wordRow(
-                            title: item,
-                            isSelected: selectedID == item,
-                            isPlaying: (selectedID == item) && isPlaying,
-                            onTap: { handleTap(itemID: item) }
-                        )
+                    Text("먼저, 단어를 들어보자!")
+                        .font(.NotoSans_24_SB)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 20)
+
+                    Spacer().frame(height: 40)
+
+                    // 단어 리스트 or 로딩
+                    if viewModel.isLoading {
+                        Spacer()
+                        ProgressView("단어를 불러오는 중...")
+                            .font(.NotoSans_24_R)
+                        Spacer()
+                    } else if let error = viewModel.errorMessage {
+                        Spacer()
+                        VStack(spacing: 16) {
+                            Text(error)
+                                .font(.NotoSans_24_R)
+                                .foregroundColor(.textGray)
+                            Button("다시 시도") {
+                                viewModel.fetchQuiz()
+                            }
+                            .font(.NotoSans_24_SB)
+                            .foregroundColor(.point)
+                        }
+                        Spacer()
+                    } else {
+                        VStack(spacing: 20) {
+                            ForEach(viewModel.words, id: \.self) { item in
+                                wordRow(
+                                    title: item,
+                                    isSelected: selectedID == item,
+                                    isPlaying: (selectedID == item) && isPlaying,
+                                    onTap: { handleTap(itemID: item) }
+                                )
+                            }
+                        }
+                        .padding(.horizontal, 20)
+
+                        Spacer()
+
+                        AcornRewards(count: successQuizCount)
+
+                        Spacer()
+
+                        CTAButton(title: "다음", type: .purple) {
+                            viewModel.setupQuiz()
+                            isNavigatingToQuiz = true
+                        }
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 60)
                     }
                 }
-                .padding(.horizontal, 20)
-
-                Spacer()
-                
-                // 도토리 획득 상황
-                AcornRewards(count: successQuizCount)
-                
-                Spacer()
-
-                // 다음 버튼
-                CTAButton(title: "다음", type: .purple) {
-                    viewModel.setupQuiz()
-                    isNavigatingToQuiz = true
-                }
-                .padding(.horizontal, 20)
-                .padding(.bottom, 60)
+                .background(Color.white.ignoresSafeArea())
             }
-            .background(Color.white.ignoresSafeArea())
-            
+            .onAppear {
+                viewModel.fetchQuiz()
+            }
             .navigationDestination(isPresented: $isNavigatingToQuiz) {
                 WordQuizRepeatView(
                     successQuizCount: successQuizCount,
@@ -93,25 +121,17 @@ struct WordLearningView: View {
         VStack(spacing: 20) {
             HStack {
                 ChipView(type: .profile(name: name, imageURL: profileUrl))
-
                 Spacer()
-                
                 HStack(spacing: 10) {
                     ChipView(type: .acorn(amount: acornAmount))
                     ChipView(type: .question)
                 }
             }
-
-            ProgressBar(
-                progress: progress,
-                height: .h8,
-                style: .purple,
-                backColor: .gray
-            )
+            ProgressBar(progress: progress, height: .h8, style: .purple, backColor: .gray)
         }
     }
 
-    // MARK: - 단어 버튼
+    // MARK: - Word Row
 
     @ViewBuilder
     private func wordRow(
@@ -122,21 +142,15 @@ struct WordLearningView: View {
     ) -> some View {
         Button(action: onTap) {
             HStack(spacing: 10) {
-                
                 Image(isPlaying ? .pause : .play)
                     .resizable()
                     .scaledToFit()
                     .frame(width: 50, height: 50)
-                
                 Spacer()
-                
                 Text(title)
                     .font(.NotoSans_30_B)
                     .foregroundStyle(.black)
-                
                 Spacer()
-                
-                // 좌우 균형용 더미 공간
                 Color.clear.frame(width: 50)
             }
             .padding(.vertical, 10)
@@ -147,9 +161,8 @@ struct WordLearningView: View {
         .buttonStyle(.plain)
     }
 
-    // MARK: - Actions / Logic
+    // MARK: - Actions
 
-    // 단어버튼 선택 로직
     private func handleTap(itemID: String) {
         if selectedID == itemID {
             isPlaying.toggle()
@@ -157,11 +170,5 @@ struct WordLearningView: View {
             selectedID = itemID
             isPlaying = true
         }
-
-        // TODO: 실제 오디오 로직 연결
     }
-}
-
-#Preview {
-    WordLearningView(successQuizCount: 2)
 }

--- a/Totori/Presentation/Quiz/WordQuizRepeatView.swift
+++ b/Totori/Presentation/Quiz/WordQuizRepeatView.swift
@@ -52,7 +52,7 @@ struct WordQuizRepeatView: View {
     let successQuizCount: Int
 
     // MARK: - State
-    @ObservedObject var viewModel = WordViewModel()
+    @ObservedObject var viewModel: WordViewModel
     
     @State private var isAnimating: Bool = false
     

--- a/Totori/Presentation/Quiz/WordQuizRepeatView.swift
+++ b/Totori/Presentation/Quiz/WordQuizRepeatView.swift
@@ -50,8 +50,6 @@ enum WordQuizStage {
 struct WordQuizRepeatView: View {
     
     let successQuizCount: Int
-
-    // MARK: - State
     @ObservedObject var viewModel: WordViewModel
     
     @State private var isAnimating: Bool = false
@@ -60,7 +58,6 @@ struct WordQuizRepeatView: View {
         ZStack {
             VStack(spacing: 0) {
                 
-                // 헤더 (칩 + 프로그레스바)
                 header(
                     name: viewModel.userName,
                     profileUrl: viewModel.profileUrl,
@@ -133,10 +130,15 @@ struct WordQuizRepeatView: View {
             Color.black.opacity(0.5)
                 .ignoresSafeArea()
                 .onTapGesture {
-                    viewModel.isShowingQuizModal = false
+                    if viewModel.isFinished {
+                        // 퀴즈 완료 → 낭독 화면으로 복귀
+                        viewModel.completeQuiz()
+                    } else {
+                        viewModel.isShowingQuizModal = false
+                    }
                 }
             
-            if(!viewModel.isFinished){
+            if !viewModel.isFinished {
                 QuizModal(type: .retry(userName: viewModel.userName))
             } else {
                 QuizModal(type: .perfect(userName: viewModel.userName))

--- a/Totori/Presentation/Quiz/WordViewModel.swift
+++ b/Totori/Presentation/Quiz/WordViewModel.swift
@@ -13,7 +13,7 @@ final class WordViewModel: ObservableObject {
     // chip
     @Published var userName: String = "김밤톨"
     @Published var profileUrl: String = "https://picsum.photos/100"
-    @Published var acornCount: Int = 10
+    @Published var acornCount: Int = 4
 
     // progress
     @Published var progress: CGFloat = 0.4

--- a/Totori/Presentation/Quiz/WordViewModel.swift
+++ b/Totori/Presentation/Quiz/WordViewModel.swift
@@ -8,8 +8,6 @@
 import Combine
 import Foundation
 
-// MARK: - ViewModel
-
 final class WordViewModel: ObservableObject {
 
     // chip
@@ -19,66 +17,140 @@ final class WordViewModel: ObservableObject {
 
     // progress
     @Published var progress: CGFloat = 0.4
-    
+
     // reward
     @Published var rewardCount: Int = 1
 
-    // wordList
-    @Published var words: [String] = [ "응원", "당연", "긍정", "정원" ]
-    
+    // MARK: - Word list
+    @Published var words: [String] = []
+
     // MARK: - Quiz State
     @Published var currentIndex: Int = 0
     @Published var stage: WordQuizStage = .mic
     @Published var isShowingQuizModal: Bool = false
     @Published var isFinished: Bool = false
 
-    // 현재 학습 중인 단어
+    // MARK: - API State
+    @Published var isLoading: Bool = true
+    @Published var errorMessage: String? = nil
+
+    private(set) var quizId: Int = 0
+    private let bookId: Int
+
+    private let quizService = QuizService()
+    private let audioRecorder = AudioRecorderManager()
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Init
+
+    init(bookId: Int) {
+        self.bookId = bookId
+    }
+
+    // MARK: - Computed
+
     var currentWord: String {
-        guard !words.isEmpty && currentIndex < words.count else { return "" }
+        guard !words.isEmpty, currentIndex < words.count else { return "" }
         return words[currentIndex]
     }
 
-    // MARK: - Logic
+    // MARK: - API
+
+    func fetchQuiz() {
+        isLoading = true
+        errorMessage = nil
+        print("📡 퀴즈 API 호출 시작 (bookId: \(bookId))")
+
+        quizService.makeQuiz(bookId: bookId)
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { [weak self] completion in
+                    guard let self else { return }
+                    self.isLoading = false
+                    if case .failure(let error) = completion {
+                        print("❌ 퀴즈 API 실패: \(error)")
+                        self.errorMessage = "퀴즈를 불러오지 못했어요"
+                    }
+                },
+                receiveValue: { [weak self] quizData in
+                    guard let self else { return }
+                    self.isLoading = false
+                    self.quizId = quizData.quizId
+                    self.words = quizData.quizItems
+                    self.currentIndex = 0
+                    self.stage = .mic
+                    self.isFinished = false
+                    print("✅ 퀴즈 데이터 수신: quizId=\(quizData.quizId), words=\(quizData.quizItems)")
+                }
+            )
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Quiz Logic
 
     func setupQuiz() {
-        self.words.shuffle()
-        self.currentIndex = 0
-        self.stage = .mic
-        self.isFinished = false
+        words.shuffle()
+        currentIndex = 0
+        stage = .mic
+        isFinished = false
     }
-    
+
     func handleMicAction() {
         switch stage {
         case .mic:
-            startSpeaking()
+            startRecording()
         case .speaking:
-            checkAnswer()
+            stopRecordingAndCheck()
         case .fail:
             retryCurrentWord()
         case .success:
             break
         }
     }
-    
-    private func startSpeaking() {
-        stage = .speaking
-        // TODO: 녹음 기능으로 변경
-        print("STT 시작")
+
+    private func startRecording() {
+        audioRecorder.requestPermission { [weak self] granted in
+            guard let self else { return }
+            if granted {
+                self.audioRecorder.startRecoding()
+                self.stage = .speaking
+                print("🎙️ 퀴즈 녹음 시작 - 단어: \(self.currentWord)")
+            } else {
+                print("❌ 마이크 권한 거부됨")
+            }
+        }
     }
     
+    private func stopRecordingAndCheck() {
+          let savedURL = audioRecorder.stopRecording()
+          print("🛑 퀴즈 녹음 종료")
+   
+          if let url = savedURL {
+              // TODO: 녹음 파일을 서버에 전송하여 정답 판정 받기
+              // 현재는 임시로 랜덤 판정
+              print("📁 녹음 파일: \(url.lastPathComponent)")
+              checkAnswer()
+          } else {
+              print("❌ 녹음 파일 저장 실패")
+              stage = .fail
+          }
+      }
+
     private func checkAnswer() {
-        // TODO: 정답여부 결과값 받아오기(일단 임시로 랜덤 설정)
-        print("STT 종료 및 결과 판정")
+        print("STT 결과 판정 중...")
+        // TODO: 서버 정답 판정 API 연결
         let isCorrect = Bool.random()
-        
+ 
         if isCorrect {
             stage = .success
+            print("✅ 정답!")
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
                 self.moveToNextWord()
             }
         } else {
             stage = .fail
             isShowingQuizModal = true
+            print("❌ 오답!")
         }
     }
 

--- a/Totori/Presentation/Quiz/WordViewModel.swift
+++ b/Totori/Presentation/Quiz/WordViewModel.swift
@@ -13,7 +13,7 @@ final class WordViewModel: ObservableObject {
     // chip
     @Published var userName: String = "김밤톨"
     @Published var profileUrl: String = "https://picsum.photos/100"
-    @Published var acornCount: Int = 4
+    @Published var acornCount: Int = 10
 
     // progress
     @Published var progress: CGFloat = 0.4
@@ -22,21 +22,21 @@ final class WordViewModel: ObservableObject {
     @Published var rewardCount: Int = 1
 
     // MARK: - Word list
-    
     @Published var words: [String] = []
 
     // MARK: - Quiz State
-    
     @Published var currentIndex: Int = 0
     @Published var stage: WordQuizStage = .mic
     @Published var isShowingQuizModal: Bool = false
     @Published var isFinished: Bool = false
 
     // MARK: - API State
-    
     @Published var isLoading: Bool = true
     @Published var errorMessage: String? = nil
     @Published var isChecking: Bool = false
+
+    /// 퀴즈 완료 시 호출할 콜백
+    var onQuizCompleted: (() -> Void)?
 
     private(set) var quizId: Int = 0
     private let bookId: Int
@@ -141,7 +141,7 @@ final class WordViewModel: ObservableObject {
         submitQuizAudio(audioURL: audioURL)
     }
 
-    // MARK: - Quiz Check
+    // MARK: - Quiz Check API
 
     private func submitQuizAudio(audioURL: URL) {
         let originalQuiz = currentWord
@@ -164,8 +164,6 @@ final class WordViewModel: ObservableObject {
                     guard let self else { return }
                     self.isChecking = false
                     print("✅ 퀴즈 채점 결과 - isCorrect: \(result.isCorrect), rewarded: \(result.rewarded), acorn: \(result.currentAcorn)")
-
-                    self.acornCount = result.currentAcorn
 
                     if result.isCorrect {
                         self.stage = .success
@@ -196,5 +194,11 @@ final class WordViewModel: ObservableObject {
     func retryCurrentWord() {
         stage = .mic
         isShowingQuizModal = false
+    }
+
+    /// 퀴즈 완료 후 낭독 화면으로 복귀
+    func completeQuiz() {
+        isShowingQuizModal = false
+        onQuizCompleted?()
     }
 }

--- a/Totori/Presentation/Quiz/WordViewModel.swift
+++ b/Totori/Presentation/Quiz/WordViewModel.swift
@@ -13,7 +13,7 @@ final class WordViewModel: ObservableObject {
     // chip
     @Published var userName: String = "김밤톨"
     @Published var profileUrl: String = "https://picsum.photos/100"
-    @Published var acornCount: Int = 10
+    @Published var acornCount: Int = 4
 
     // progress
     @Published var progress: CGFloat = 0.4
@@ -22,17 +22,21 @@ final class WordViewModel: ObservableObject {
     @Published var rewardCount: Int = 1
 
     // MARK: - Word list
+    
     @Published var words: [String] = []
 
     // MARK: - Quiz State
+    
     @Published var currentIndex: Int = 0
     @Published var stage: WordQuizStage = .mic
     @Published var isShowingQuizModal: Bool = false
     @Published var isFinished: Bool = false
 
     // MARK: - API State
+    
     @Published var isLoading: Bool = true
     @Published var errorMessage: String? = nil
+    @Published var isChecking: Bool = false
 
     private(set) var quizId: Int = 0
     private let bookId: Int
@@ -108,6 +112,8 @@ final class WordViewModel: ObservableObject {
         }
     }
 
+    // MARK: - Recording
+
     private func startRecording() {
         audioRecorder.requestPermission { [weak self] granted in
             guard let self else { return }
@@ -120,38 +126,61 @@ final class WordViewModel: ObservableObject {
             }
         }
     }
-    
-    private func stopRecordingAndCheck() {
-          let savedURL = audioRecorder.stopRecording()
-          print("🛑 퀴즈 녹음 종료")
-   
-          if let url = savedURL {
-              // TODO: 녹음 파일을 서버에 전송하여 정답 판정 받기
-              // 현재는 임시로 랜덤 판정
-              print("📁 녹음 파일: \(url.lastPathComponent)")
-              checkAnswer()
-          } else {
-              print("❌ 녹음 파일 저장 실패")
-              stage = .fail
-          }
-      }
 
-    private func checkAnswer() {
-        print("STT 결과 판정 중...")
-        // TODO: 서버 정답 판정 API 연결
-        let isCorrect = Bool.random()
- 
-        if isCorrect {
-            stage = .success
-            print("✅ 정답!")
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                self.moveToNextWord()
-            }
-        } else {
+    private func stopRecordingAndCheck() {
+        let savedURL = audioRecorder.stopRecording()
+        print("🛑 퀴즈 녹음 종료")
+
+        guard let audioURL = savedURL else {
+            print("❌ 녹음 파일 저장 실패")
             stage = .fail
-            isShowingQuizModal = true
-            print("❌ 오답!")
+            return
         }
+
+        print("📁 녹음 파일: \(audioURL.lastPathComponent)")
+        submitQuizAudio(audioURL: audioURL)
+    }
+
+    // MARK: - Quiz Check
+
+    private func submitQuizAudio(audioURL: URL) {
+        let originalQuiz = currentWord
+        isChecking = true
+        print("📡 퀴즈 채점 API 호출 - quizId: \(quizId), 원본: \(originalQuiz)")
+
+        quizService.checkQuiz(quizId: quizId, audioURL: audioURL, originalQuiz: originalQuiz)
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { [weak self] completion in
+                    guard let self else { return }
+                    self.isChecking = false
+                    if case .failure(let error) = completion {
+                        print("❌ 퀴즈 채점 API 실패: \(error)")
+                        self.stage = .fail
+                        self.isShowingQuizModal = true
+                    }
+                },
+                receiveValue: { [weak self] result in
+                    guard let self else { return }
+                    self.isChecking = false
+                    print("✅ 퀴즈 채점 결과 - isCorrect: \(result.isCorrect), rewarded: \(result.rewarded), acorn: \(result.currentAcorn)")
+
+                    self.acornCount = result.currentAcorn
+
+                    if result.isCorrect {
+                        self.stage = .success
+                        print("🎉 정답!")
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                            self.moveToNextWord()
+                        }
+                    } else {
+                        self.stage = .fail
+                        self.isShowingQuizModal = true
+                        print("😢 오답!")
+                    }
+                }
+            )
+            .store(in: &cancellables)
     }
 
     func moveToNextWord() {

--- a/Totori/Presentation/ReadStoryBook/View/ReadStoryBookView.swift
+++ b/Totori/Presentation/ReadStoryBook/View/ReadStoryBookView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-
 import Kingfisher
 
 struct ReadStoryBookView: View {
@@ -77,9 +76,13 @@ struct ReadStoryBookView: View {
         .onAppear {
             switch source {
             case .generated(let bookData):
-                viewModel.setUpData(bookData: bookData)
+                if viewModel.displayPages.isEmpty {
+                    viewModel.setUpData(bookData: bookData)
+                }
             case .detail(let bookDetail):
-                viewModel.setUpData(bookDetail: bookDetail)
+                if viewModel.displayPages.isEmpty {
+                    viewModel.setUpData(bookDetail: bookDetail)
+                }
             }
         }
         .navigationDestination(isPresented: $navigateToStart) {
@@ -97,7 +100,12 @@ struct ReadStoryBookView: View {
         .navigationDestination(isPresented: $viewModel.navigateToQuiz) {
             WordLearningView(
                 successQuizCount: 0,
-                bookId: viewModel.bookId
+                bookId: viewModel.bookId,
+                onComplete: {
+                    // 퀴즈 완료 → navigateToQuiz를 false로 돌리면
+                    // navigationDestination이 자동으로 pop됨
+                    viewModel.navigateToQuiz = false
+                }
             )
             .navigationBarBackButtonHidden(true)
         }

--- a/Totori/Presentation/ReadStoryBook/View/ReadStoryBookView.swift
+++ b/Totori/Presentation/ReadStoryBook/View/ReadStoryBookView.swift
@@ -35,7 +35,7 @@ struct ReadStoryBookView: View {
             VStack {
                 Button(action: {
                     showModal = true
-                }){
+                }) {
                     Image(.close)
                         .resizable()
                         .scaledToFit()
@@ -43,7 +43,6 @@ struct ReadStoryBookView: View {
                         .padding(.top, 80)
                         .padding(.leading, 322)
                 }
-                
                 Spacer()
             }
             .zIndex(2)
@@ -94,6 +93,13 @@ struct ReadStoryBookView: View {
         .navigationDestination(isPresented: $viewModel.navigateToFinish) {
             BookEndView()
                 .navigationBarBackButtonHidden(true)
+        }
+        .navigationDestination(isPresented: $viewModel.navigateToQuiz) {
+            WordLearningView(
+                successQuizCount: 0,
+                bookId: viewModel.bookId
+            )
+            .navigationBarBackButtonHidden(true)
         }
     }
     

--- a/Totori/Presentation/ReadStoryBook/ViewModel/ReadStoryBookViewModel.swift
+++ b/Totori/Presentation/ReadStoryBook/ViewModel/ReadStoryBookViewModel.swift
@@ -21,6 +21,9 @@ class ReadStoryBookViewModel: ObservableObject {
     @Published var navigateToBadge: Bool = false
     @Published var navigateToFinish: Bool = false
     
+    @Published var navigateToQuiz: Bool = false
+    @Published var pendingQuizData: QuizResponseDTO? = nil
+    
     private let audioRecorder = AudioRecorderManager()
     
     private(set) var lastRecordedURL: URL?
@@ -32,6 +35,9 @@ class ReadStoryBookViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var bookId: Int = 0
     
+    private var quizInterval: Int = 18
+    private var quizImageCount: Int = 6
+    
     init() {}
     
     // BookGenerateResponseDTO 버전
@@ -42,6 +48,7 @@ class ReadStoryBookViewModel: ObservableObject {
         var globalIdx = 0
         
         let sortedPages = bookData.pages.sorted { $0.pageOrder < $1.pageOrder }
+        
         
         for page in sortedPages {
             for sentence in page.sentences {

--- a/Totori/Presentation/ReadStoryBook/ViewModel/ReadStoryBookViewModel.swift
+++ b/Totori/Presentation/ReadStoryBook/ViewModel/ReadStoryBookViewModel.swift
@@ -22,7 +22,6 @@ class ReadStoryBookViewModel: ObservableObject {
     @Published var navigateToFinish: Bool = false
     
     @Published var navigateToQuiz: Bool = false
-    @Published var pendingQuizData: QuizResponseDTO? = nil
     
     private let audioRecorder = AudioRecorderManager()
     
@@ -33,61 +32,62 @@ class ReadStoryBookViewModel: ObservableObject {
     
     private let bookService = BookService()
     private var cancellables = Set<AnyCancellable>()
-    private var bookId: Int = 0
     
-    private var quizInterval: Int = 18
-    private var quizImageCount: Int = 6
+    private(set) var bookId: Int = 0
+    private var quizInterval: Int = 6
     
     init() {}
     
-    // BookGenerateResponseDTO 버전
+    // MARK: - Setup
+    
     func setUpData(bookData: BookGenerateResponseDTO) {
         self.bookId = bookData.bookId
         print("📚 bookId 세팅: \(self.bookId)")
         var flatList: [DisplayPage] = []
         var globalIdx = 0
         
-        let sortedPages = bookData.pages.sorted { $0.pageOrder < $1.pageOrder }
-        
-        
-        for page in sortedPages {
+        for page in bookData.pages.sorted(by: { $0.pageOrder < $1.pageOrder }) {
             for sentence in page.sentences {
-                let displayPage = DisplayPage(
+                flatList.append(DisplayPage(
                     globalIndex: globalIdx,
                     imageUrl: page.imageUrl,
                     text: sentence.text,
                     audioUrl: sentence.audioUrl
-                )
-                flatList.append(displayPage)
+                ))
                 globalIdx += 1
             }
         }
         self.displayPages = flatList
+        configureQuizInterval()
     }
-
-    // BookDetailResponseDTO 버전
+    
     func setUpData(bookDetail: BookDetailResponseDTO) {
         self.bookId = bookDetail.cover.bookId
         print("📚 bookId 세팅: \(self.bookId)")
         var flatList: [DisplayPage] = []
         var globalIdx = 0
         
-        let sortedPages = bookDetail.pages.sorted { $0.pageOrder < $1.pageOrder }
-        
-        for page in sortedPages {
+        for page in bookDetail.pages.sorted(by: { $0.pageOrder < $1.pageOrder }) {
             for sentence in page.sentences {
-                let displayPage = DisplayPage(
+                flatList.append(DisplayPage(
                     globalIndex: globalIdx,
                     imageUrl: page.imageUrl,
                     text: sentence.text,
                     audioUrl: sentence.audioUrl
-                )
-                flatList.append(displayPage)
+                ))
                 globalIdx += 1
             }
         }
         self.displayPages = flatList
+        configureQuizInterval()
     }
+    
+    private func configureQuizInterval() {
+        quizInterval = displayPages.count <= 18 ? 6 : 9
+        print("📝 퀴즈 간격: \(quizInterval) pages (총 \(displayPages.count)페이지)")
+    }
+    
+    // MARK: - Computed Properties
     
     var currentDisplayPage: DisplayPage {
         guard !displayPages.isEmpty else {
@@ -114,9 +114,10 @@ class ReadStoryBookViewModel: ObservableObject {
             stopRecordingFlow()
         }
         
-        if currentIndex < displayPages.count - 1{
+        if currentIndex < displayPages.count - 1 {
             withAnimation { currentIndex += 1 }
             resetPageStates()
+            checkQuizTrigger()
         } else {
             checkBadgeCompletion()
         }
@@ -133,6 +134,18 @@ class ReadStoryBookViewModel: ObservableObject {
         resetPageStates()
     }
     
+    // MARK: - Quiz Trigger
+    
+    private func checkQuizTrigger() {
+        let oneBased = currentIndex + 1
+        guard oneBased % quizInterval == 0 else { return }
+        print("🎯 퀴즈 트리거! page index: \(currentIndex)")
+        // 바로 화면 이동 — API는 WordViewModel에서 호출
+        navigateToQuiz = true
+    }
+    
+    // MARK: - TTS
+    
     func toggleMic() {
         if isMicRecording {
             stopRecordingFlow()
@@ -140,8 +153,8 @@ class ReadStoryBookViewModel: ObservableObject {
             startRecordingFlow()
         }
     }
+    
     func toggleTTS() {
-        // 이미 재생 중이면 멈춤
         if isTTSSpeaking {
             stopAudio()
             return
@@ -175,20 +188,18 @@ class ReadStoryBookViewModel: ObservableObject {
         NotificationCenter.default.removeObserver(self, name: .AVPlayerItemDidPlayToEndTime, object: nil)
     }
     
-    // 페이지가 넘어갈 때 재생 중인 오디오 강제 종료
-    
     // MARK: - Recording Flow
     
     private func startRecordingFlow() {
         if isTTSSpeaking {
-            withAnimation{ isTTSSpeaking = false }
+            withAnimation { isTTSSpeaking = false }
         }
         
         audioRecorder.requestPermission { [weak self] granted in
             guard let self = self else { return }
             if granted {
                 self.audioRecorder.startRecoding()
-                withAnimation{ self.isMicRecording = true }
+                withAnimation { self.isMicRecording = true }
             } else {
                 print("마이크 권한 거부됨")
             }
@@ -231,10 +242,7 @@ class ReadStoryBookViewModel: ObservableObject {
     func togglePanel() { withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) { isPanelVisible.toggle() } }
     
     private func checkBadgeCompletion() {
-        // TODO: 서버에 뱃지 획득 확인 API 전송
         print("API Request: 뱃지 획득 여부 확인 중...")
-        
-        //TODO: 뱃지 획득 API 연결
         let isBadgeEarned = Bool.random()
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #69
<br>

## 🍎 작업 내용
- 동화 낭독 시 레벨 1-3은 6페이지마다, 4-6은 9페이지마다 퀴즈가 등장하도록 하였습니다. 
- 6페이지 낭독후 다음 페이지 등장전 퀴즈 화면으로 이동하고 퀴즈 생성 api가 호출 됩니다. 
- 퀴즈 생성에 시간이 소요되므로 로딩화면이 보여지고 퀴즈가 생성되면 화면이 보여집니다. 
- 퀴즈 반복 학습 화면의 api를 연결하여 음성을 보내고 정답여부를 반환합니다. 
- 퀴즈를 모두 맞추면 원래 낭독하던 화면으로 돌아갑니다.     
<br>

## 💬 리뷰 코멘트
